### PR TITLE
Consider using DIDs in Issuer profiles to reference keys

### DIFF
--- a/cert_schema/2.1/issuerSchema.json
+++ b/cert_schema/2.1/issuerSchema.json
@@ -66,8 +66,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "pattern": "^ecdsa-koblitz-pubkey:",
-          "description": "Issuer public key or blockchain address IRI with `<scheme>:` prefix. For Bitcoin transactions, this would be the issuer public address prefixed with `ecdsa-koblitz-pubkey:`; e.g. `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`"
+          "pattern": "^(ecdsa-koblitz-pubkey|did):",
+          "description": "Issuer public key or blockchain address IRI with `<scheme>:` prefix. For Bitcoin transactions, this would be the issuer public address prefixed with `ecdsa-koblitz-pubkey:`; e.g. `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`. If scheme is `did`, the DID URL of the key"
         },
         "created": {
           "$ref": "#/definitions/DateTime"

--- a/docs/issuer_schema-2.1.md
+++ b/docs/issuer_schema-2.1.md
@@ -59,11 +59,11 @@ Properties of the `CryptographicKey` object:
 
 #### `id` (string)
 
-Issuer public key or blockchain address IRI with `<scheme>:` prefix. For Bitcoin transactions, this would be the issuer public address prefixed with `ecdsa-koblitz-pubkey:`; e.g. `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`
+Issuer public key or blockchain address IRI with `<scheme>:` prefix. For Bitcoin transactions, this would be the issuer public address prefixed with `ecdsa-koblitz-pubkey:`; e.g. `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`. If scheme is `did`, the DID URL of the key
 
 Additional restrictions:
 
-* Regex pattern: `^ecdsa-koblitz-pubkey:`
+* Regex pattern: `^(ecdsa-koblitz-pubkey|did):`
 
 #### `created` (DateTime, required)
 


### PR DESCRIPTION
This pull request would allow using `DID URL`s to identify keys in IssuerProfiles. A little step towards DID adoption in Blockcerts.

We could consider to allow this scheme in the `VerificationObject` too but without having to specify the specific key (so a DID instead of a DID URL). This way any valid authentication key would be a valid key to be used on blockchain registrations.

Based on post
https://community.blockcerts.org/t/dids-as-a-way-to-properly-identify-issuers/2085