### PR TITLE
Remove ambiguous ethereumTestnet from anchor chains

### DIFF
--- a/docs/merkleProofSignatureExtension_schema.md
+++ b/docs/merkleProofSignatureExtension_schema.md
@@ -41,7 +41,6 @@ Chain is an optional field introduced by Blockcerts to help during verification.
 - bitcoinRegtest
 - ethereumMainnet
 - ethereumRopsten
-- ethereumTestnet
 - mockchain
 
 


### PR DESCRIPTION
Ethereum testnet is ambiguous as there are multiple ones

More discussion in Blockcerts community forum:

https://community.blockcerts.org/t/merkleproof2017-ethereum-testnet-not-properly-identified/2097

@anthonyronning