### PR TITLE
Update missing items in context.json

### DIFF
--- a/cert_schema/2.0/context.json
+++ b/cert_schema/2.0/context.json
@@ -43,13 +43,15 @@
     },
 
     "BTCOpReturn": "cp:BTCOpReturn",
+    "ETHData": "cp:ETHData",
     "targetHash": "cp:targetHash",
     "merkleRoot": "cp:merkleRoot",
     "proof": "cp:proof",
     "anchors": "cp:anchors",
     "sourceId": "cp:sourceId",
     "right": "cp:right",
-    "left": "cp:left"
+    "left": "cp:left",
+    "chain": "bc:chain"
   },
   "obi:validation": [
     {

--- a/cert_schema/2.1/context.json
+++ b/cert_schema/2.1/context.json
@@ -43,13 +43,15 @@
     },
 
     "BTCOpReturn": "cp:BTCOpReturn",
+    "ETHData": "cp:ETHData",
     "targetHash": "cp:targetHash",
     "merkleRoot": "cp:merkleRoot",
     "proof": "cp:proof",
     "anchors": "cp:anchors",
     "sourceId": "cp:sourceId",
     "right": "cp:right",
-    "left": "cp:left"
+    "left": "cp:left",
+    "chain": "bc:chain"
   },
   "obi:validation": [
     {


### PR DESCRIPTION
After processing several assertions using the 2.0 and 2.1 context.json, I've found two missing items in the context that are accepted by the Blockcerts and Chainpoint standards:

- [`ETHData` type (possible value of `.signature.anchor.type`)](https://chainpoint.org/)
- [`chain` field (optional field in `.signature.anchor`)](https://github.com/blockchain-certificates/cert-schema/blob/master/docs/merkleProofSignatureExtension_schema.md#chain-string)